### PR TITLE
Fix URL to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 <div align="center">
 	<br>
-	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/master/header.svg">
+	<a href="https://raw.githubusercontent.com/sindresorhus/css-in-readme-like-wat/master/readme.md">
 		<img src="header.svg" width="800" height="400">
 	</a>
 	<br>


### PR DESCRIPTION
The repo URL says that the magic is in the readme, so instead of linking to the svg, link to the raw readme, so when the visitor opens the link, he can see what he expect to see, the readme.