### PR TITLE
Use markdown in markdown instead of HTML

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,1 @@
-<div align="center">
-	<br>
-	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/master/header.svg">
-		<img src="header.svg" width="800" height="400">
-	</a>
-	<br>
-</div>
+[![](header.svg)](https://github.com/sindresorhus/css-in-readme-like-wat/blame/master/header.svg)


### PR DESCRIPTION
Markdown is more readable than HTML, and since the readme has the `md` extension, it should stay as close to markdown as possible.
You can also link and embed image in markdown as well, you so you really don't need HTML for that.