### PR TITLE
Add alt text to image

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<br>
 	<a href="https://raw.githubusercontent.com/sindresorhus/css-in-readme-like-wat/master/readme.md">
-		<img src="header.svg" width="800" height="400">
+		<img src="header.svg" width="800" height="400" alt="Click to see the source">
 	</a>
 	<br>
 </div>


### PR DESCRIPTION
When a link contains only an image, it is necessary to add alt text to the image. The alt text serves as the link’s label. When screen reader users focus an image link, the alt text is announced. Without alt text, nothing is announced.