### PR TITLE
Fix mobile header

### DIFF
--- a/header-mobile.svg
+++ b/header-mobile.svg
@@ -1,0 +1,90 @@
+<svg fill="none" viewBox="0 0 320 400" width="320" height="400" xmlns="http://www.w3.org/2000/svg">
+	<foreignObject width="100%" height="100%">
+		<div xmlns="http://www.w3.org/1999/xhtml">
+			<style>
+				@keyframes rotate {
+					0% {
+						transform: rotate(3deg);
+					}
+					100% {
+						transform: rotate(-3deg);
+					}
+				}
+
+				@keyframes gradientBackground {
+					0% {
+						background-position: 0% 50%;
+					}
+					50% {
+						background-position: 100% 50%;
+					}
+					100% {
+						background-position: 0% 50%;
+					}
+				}
+
+				@keyframes fadeIn {
+					0% {
+						opacity: 0;
+					}
+					66% {
+						opacity: 0;
+					}
+					100% {
+						opacity: 1;
+					}
+				}
+
+				.container {
+					font-family:
+						system-ui,
+						-apple-system,
+						'Segoe UI',
+						Roboto,
+						Helvetica,
+						Arial,
+						sans-serif,
+						'Apple Color Emoji',
+						'Segoe UI Emoji';
+					display: flex;
+					flex-direction: column;
+					align-items: center;
+					justify-content: center;
+					margin: 0;
+					width: 100%;
+					height: 400px;
+					background: linear-gradient(-45deg, #fc5c7d, #6a82fb, #05dfd7);
+					background-size: 600% 400%;
+					animation: gradientBackground 10s ease infinite;
+					border-radius: 10px;
+					color: white;
+					text-align: center;
+				}
+
+				h1 {
+					font-size: 32px;
+					line-height: 1.3;
+					letter-spacing: 5px;
+					text-transform: uppercase;
+					text-shadow:
+						0 1px 0 #efefef,
+						0 2px 0 #efefef,
+						0 3px 0 #efefef,
+						0 4px 0 #efefef,
+						0 12px 5px rgba(0, 0, 0, 0.1);
+					animation: rotate ease-in-out 1s infinite alternate;
+				}
+
+				p {
+					font-size: 16px;
+					text-shadow: 0 1px 0 #efefef;
+					animation: 5s ease 0s normal forwards 1 fadeIn;
+				}
+			</style>
+			<div class="container">
+				<h1>Made with HTML &amp; CSS<br/>not an animated GIF</h1>
+				<p>Click to see the source</p>
+			</div>
+		</div>
+	</foreignObject>
+</svg>

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,13 @@
 <div align="center">
 	<br>
 	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/main/header.svg">
-		<img src="header.svg" width="800" height="400" alt="Click to see the source">
+		<picture>
+		  <source media="(mmin-width: 720px)" srcset="header.svg">
+		  <img src="header-mobile.svg" width="800" height="400" alt="Click to see the source">
+		</picture>
 	</a>
 	<br>
 </div>
-
-
-
-<br>
-<br>
-<br>
-<br>
 <br>
 <br>
 Explanation: https://css-tricks.com/custom-styles-in-github-readmes/

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 	<br>
 	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/main/header.svg">
 		<picture>
-		  <source media="(mmin-width: 720px)" srcset="header.svg">
+		  <source media="(min-width: 720px)" srcset="header.svg">
 		  <img src="header-mobile.svg" width="800" height="400" alt="Click to see the source">
 		</picture>
 	</a>


### PR DESCRIPTION
closes #10

I found [this](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) documentation for markdown files inside GitHub.

Basiclly, we need to add another `header-mobile.svg` and can use `<source media=...>` 👍

You can check it [here](https://github.com/nmerget/css-in-readme-like-wat/tree/fix-mobile-header) with the mobile app or with DevTools.

@sindresorhus: **like-what** 😮