### PR TITLE
preserve-3d rotationY doesn't appear to work

### DIFF
--- a/header.svg
+++ b/header.svg
@@ -65,7 +65,6 @@
 				p {
 					font-size: 40px;
 					text-shadow: 0 1px 0 #efefef;
-					animation: 5s ease 0s normal forwards 1 fadeIn;
 				}
 
 				.flip-card {

--- a/header.svg
+++ b/header.svg
@@ -58,11 +58,7 @@
 					margin: 0;
 					width: 100%;
 					height: 300px;
-					background: linear-gradient(-45deg, #fc5c7d, #6a82fb, #05dfd7);
-					background-size: 600% 400%;
-					animation: gradientBackground 10s ease infinite;
 					border-radius: 10px;
-					color: white;
 					text-align: center;
 				}
 
@@ -120,7 +116,7 @@
             		<div class="flip-card-inner">
               			<div class="flip-card-front">
 							<picture>
-								<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+								<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
 									<text x="20" y="170" font-size="100" font-family="Arial" fill="black">d</text>
 
 									<rect x="80" y="130" width="30" height="40" fill="lightblue" stroke="black"/>

--- a/header.svg
+++ b/header.svg
@@ -63,7 +63,7 @@
 				}
 
 				p {
-					font-size: 20px;
+					font-size: 40px;
 					text-shadow: 0 1px 0 #efefef;
 					animation: 5s ease 0s normal forwards 1 fadeIn;
 				}
@@ -131,6 +131,8 @@
 						</div>
 						<div class="flip-card-back">
 							<p>distributed</p>
+							<p>digital</p>
+							<p>library</p>
 						</div>
 					</div>
 				</div>

--- a/header.svg
+++ b/header.svg
@@ -97,7 +97,7 @@
 					transition: transform 2.9s;
 					transform-style: preserve-3d;
 					box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-					animation: rotate ease-in-out 3s infinite;
+					animation: rotate ease-in-out 9s infinite;
 				}
 
 				.flip-card:hover .flip-card-inner {

--- a/header.svg
+++ b/header.svg
@@ -81,6 +81,8 @@
 					width: 100%;
 					height: 100%;
 					text-align: center;
+					background-color: #ccc;
+					color: black;
 					transition: transform 2.9s;
 					transform-style: preserve-3d;
 					box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
@@ -99,14 +101,8 @@
 					backface-visibility: hidden;
 				}
 
-				.flip-card-front {
-					background-color: #ccc;
-					color: black;
-				}
-
 				.flip-card-back {
-					background-color: #ccc;
-					color: black;
+					transform: rotateY(180deg);
 				}
 
 			</style>

--- a/header.svg
+++ b/header.svg
@@ -102,7 +102,7 @@
 				}
 
 				.flip-card-front {
-					background-color: #ccc;
+					background-color: #888;
 					color: black;
 				}
 

--- a/header.svg
+++ b/header.svg
@@ -86,7 +86,6 @@
 					width: 300px;
 					height: 300px;
 					perspective: 1000px;
-					animation: rotate ease-in-out 1s infinite alternate;
 				}
 
 				.flip-card-inner {
@@ -97,6 +96,7 @@
 					transition: transform 2.9s;
 					transform-style: preserve-3d;
 					box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+					animation: rotate ease-in-out 3s infinite alternate;
 				}
 
 				.flip-card:hover .flip-card-inner {

--- a/header.svg
+++ b/header.svg
@@ -4,7 +4,7 @@
 			<style>
 				@keyframes rotate {
 					0% {
-						transform: rotateY(30deg);
+						transform: rotateY(270deg);
 					}
 					100% {
 						transform: rotateY(180deg);

--- a/header.svg
+++ b/header.svg
@@ -101,7 +101,6 @@
 				}
 
 				.flip-card-front {
-					background-color: #888;
 					color: black;
 				}
 

--- a/header.svg
+++ b/header.svg
@@ -116,7 +116,7 @@
             		<div class="flip-card-inner">
               			<div class="flip-card-front">
 							<picture>
-								<svg width="300" height="300" viewBox="0 100 300 200" xmlns="http://www.w3.org/2000/svg">
+								<svg width="300" height="300" viewBox="0 50 260 200" xmlns="http://www.w3.org/2000/svg">
 									<text x="20" y="170" font-size="100" font-family="Arial" fill="black">d</text>
 
 									<rect x="80" y="130" width="30" height="40" fill="lightblue" stroke="black"/>

--- a/header.svg
+++ b/header.svg
@@ -6,12 +6,10 @@
 					0% {
 						transform: rotateY(0deg);
 					}
-					50% {
-						transform: rotateY(180deg);
-					}
-					100% {
-						transform: rotateY(360deg);
-					}
+					47% {transform: rotateY(180deg); }
+					50% {transform: rotateY(180deg); }
+					97% { transform: rotateY(360deg); }
+					100% { transform: rotateY(360deg); }
 				}
 
 				@keyframes gradientBackground {

--- a/header.svg
+++ b/header.svg
@@ -107,7 +107,6 @@
 				.flip-card-back {
 					background-color: #ccc;
 					color: black;
-					transform: rotateY(180deg);
 				}
 
 			</style>

--- a/header.svg
+++ b/header.svg
@@ -82,8 +82,32 @@
 				}
 			</style>
 			<div class="container">
-				<h1>Made with HTML &amp; CSS<br/>not an animated GIF</h1>
-				<p>Click to see the source</p>
+				<div class="flip-card">
+            		<div class="flip-card-inner">
+              			<div class="flip-card-front">
+							<picture>
+								<svg width="300" height="300" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+									<text x="20" y="170" font-size="100" font-family="Arial" fill="black">d</text>
+
+									<rect x="80" y="130" width="30" height="40" fill="lightblue" stroke="black"/>
+									<circle cx="95" cy="100" r="15" fill="lightblue" stroke="black" />
+									<rect x="115" y="70" width="30" height="100" fill="darkgreen" stroke="black"/>
+									<rect x="150" y="130" width="30" height="40" fill="lightblue" stroke="black"/>
+									<circle cx="165" cy="100" r="15" fill="lightblue" stroke="black" />
+									<text x="185" y="170" font-size="100" font-family="Arial" fill="black">b</text>
+									<text x="60" y="235" font-size="50" font-family="Arial" fill="black">[ .org ]</text>
+								</svg>
+							</picture>
+							<h1>Made with HTML &amp; CSS<br/>not an animated GIF</h1>
+							<p>Click to see the source</p>
+						</div>
+						<div class="flip-card-back">
+							<h1>John Doe</h1>
+							<p>Architect &amp; Engineer</p>
+							<p>We love that guy</p>
+						</div>
+					</div>
+				</div>
 			</div>
 		</div>
 	</foreignObject>

--- a/header.svg
+++ b/header.svg
@@ -57,7 +57,7 @@
 					justify-content: center;
 					margin: 0;
 					width: 100%;
-					height: 400px;
+					height: 300px;
 					background: linear-gradient(-45deg, #fc5c7d, #6a82fb, #05dfd7);
 					background-size: 600% 400%;
 					animation: gradientBackground 10s ease infinite;
@@ -120,7 +120,7 @@
             		<div class="flip-card-inner">
               			<div class="flip-card-front">
 							<picture>
-								<svg width="300" height="300" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+								<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
 									<text x="20" y="170" font-size="100" font-family="Arial" fill="black">d</text>
 
 									<rect x="80" y="130" width="30" height="40" fill="lightblue" stroke="black"/>

--- a/header.svg
+++ b/header.svg
@@ -87,6 +87,10 @@
 					animation: rotate ease-in-out 9s infinite;
 				}
 
+				.flip-card:hover .flip-card-inner {
+					transform: rotateY(180deg);
+				}
+
 				.flip-card-front, .flip-card-back {
 					position: absolute;
 					width: 100%;
@@ -103,6 +107,7 @@
 				.flip-card-back {
 					background-color: #ccc;
 					color: black;
+					transform: rotateY(180deg);
 				}
 
 			</style>

--- a/header.svg
+++ b/header.svg
@@ -4,10 +4,10 @@
 			<style>
 				@keyframes rotate {
 					0% {
-						transform: rotate(3deg);
+						transform: rotateY(30deg);
 					}
 					100% {
-						transform: rotate(-3deg);
+						transform: rotateY(180deg);
 					}
 				}
 

--- a/header.svg
+++ b/header.svg
@@ -87,10 +87,6 @@
 					animation: rotate ease-in-out 9s infinite;
 				}
 
-				.flip-card:hover .flip-card-inner {
-					transform: rotateY(180deg);
-				}
-
 				.flip-card-front, .flip-card-back {
 					position: absolute;
 					width: 100%;
@@ -107,7 +103,6 @@
 				.flip-card-back {
 					background-color: #ccc;
 					color: black;
-					transform: rotateY(180deg);
 				}
 
 			</style>

--- a/header.svg
+++ b/header.svg
@@ -116,7 +116,7 @@
             		<div class="flip-card-inner">
               			<div class="flip-card-front">
 							<picture>
-								<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+								<svg width="300" height="300" viewBox="0 100 300 200" xmlns="http://www.w3.org/2000/svg">
 									<text x="20" y="170" font-size="100" font-family="Arial" fill="black">d</text>
 
 									<rect x="80" y="130" width="30" height="40" fill="lightblue" stroke="black"/>

--- a/header.svg
+++ b/header.svg
@@ -6,6 +6,9 @@
 					0% {
 						transform: rotateY(0deg);
 					}
+					50% {
+						transform: rotateY(180deg);
+					}
 					100% {
 						transform: rotateY(360deg);
 					}
@@ -96,7 +99,7 @@
 					transition: transform 2.9s;
 					transform-style: preserve-3d;
 					box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
-					animation: rotate ease-in-out 3s infinite alternate;
+					animation: rotate ease-in-out 3s infinite;
 				}
 
 				.flip-card:hover .flip-card-inner {

--- a/header.svg
+++ b/header.svg
@@ -7,8 +7,10 @@
 						transform: rotateY(0deg);
 					}
 					47% {transform: rotateY(180deg); }
+					48% {transform: rotateY(180deg); }
 					50% {transform: rotateY(180deg); }
 					97% { transform: rotateY(360deg); }
+					98% { transform: rotateY(360deg); }
 					100% { transform: rotateY(360deg); }
 				}
 

--- a/header.svg
+++ b/header.svg
@@ -8,9 +8,11 @@
 					}
 					47% {transform: rotateY(180deg); }
 					48% {transform: rotateY(180deg); }
+					49% {transform: rotateY(180deg); }
 					50% {transform: rotateY(180deg); }
 					97% { transform: rotateY(360deg); }
 					98% { transform: rotateY(360deg); }
+					99% { transform: rotateY(360deg); }
 					100% { transform: rotateY(360deg); }
 				}
 

--- a/header.svg
+++ b/header.svg
@@ -72,7 +72,6 @@
 						0 3px 0 #efefef,
 						0 4px 0 #efefef,
 						0 12px 5px rgba(0, 0, 0, 0.1);
-					animation: rotate ease-in-out 1s infinite alternate;
 				}
 
 				p {
@@ -87,6 +86,7 @@
 					width: 300px;
 					height: 300px;
 					perspective: 1000px;
+					animation: rotate ease-in-out 1s infinite alternate;
 				}
 
 				.flip-card-inner {

--- a/header.svg
+++ b/header.svg
@@ -99,7 +99,7 @@
 								</svg>
 							</picture>
 							<h1>Made with HTML &amp; CSS<br/>not an animated GIF</h1>
-							<p>Click to see the source</p>
+							<p>Click to see source</p>
 						</div>
 						<div class="flip-card-back">
 							<h1>John Doe</h1>

--- a/header.svg
+++ b/header.svg
@@ -101,6 +101,11 @@
 					backface-visibility: hidden;
 				}
 
+				.flip-card-front {
+					background-color: #ccc;
+					color: black;
+				}
+
 				.flip-card-back {
 					transform: rotateY(180deg);
 				}

--- a/header.svg
+++ b/header.svg
@@ -80,6 +80,48 @@
 					text-shadow: 0 1px 0 #efefef;
 					animation: 5s ease 0s normal forwards 1 fadeIn;
 				}
+
+				.flip-card {
+					font-family: Arial, Helvetica, sans-serif;
+					background-color: transparent;
+					width: 300px;
+					height: 300px;
+					perspective: 1000px;
+				}
+
+				.flip-card-inner {
+					position: relative;
+					width: 100%;
+					height: 100%;
+					text-align: center;
+					transition: transform 2.9s;
+					transform-style: preserve-3d;
+					box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2);
+				}
+
+				.flip-card:hover .flip-card-inner {
+					transform: rotateY(180deg);
+				}
+
+				.flip-card-front, .flip-card-back {
+					position: absolute;
+					width: 100%;
+					height: 100%;
+					-webkit-backface-visibility: hidden;
+					backface-visibility: hidden;
+				}
+
+				.flip-card-front {
+					background-color: #ccc;
+					color: black;
+				}
+
+				.flip-card-back {
+					background-color: #ccc;
+					color: black;
+					transform: rotateY(180deg);
+				}
+
 			</style>
 			<div class="container">
 				<div class="flip-card">

--- a/header.svg
+++ b/header.svg
@@ -1,4 +1,4 @@
-<svg fill="none" viewBox="0 0 800 400" width="800" height="400" xmlns="http://www.w3.org/2000/svg">
+<svg fill="none" viewBox="0 0 300 300" width="300" height="300" xmlns="http://www.w3.org/2000/svg">
 	<foreignObject width="100%" height="100%">
 		<div xmlns="http://www.w3.org/1999/xhtml">
 			<style>
@@ -64,19 +64,6 @@
 					border-radius: 10px;
 					color: white;
 					text-align: center;
-				}
-
-				h1 {
-					font-size: 50px;
-					line-height: 1.3;
-					letter-spacing: 5px;
-					text-transform: uppercase;
-					text-shadow:
-						0 1px 0 #efefef,
-						0 2px 0 #efefef,
-						0 3px 0 #efefef,
-						0 4px 0 #efefef,
-						0 12px 5px rgba(0, 0, 0, 0.1);
 				}
 
 				p {
@@ -147,9 +134,7 @@
 							</picture>
 						</div>
 						<div class="flip-card-back">
-							<h1>John Doe</h1>
-							<p>Architect &amp; Engineer</p>
-							<p>We love that guy</p>
+							<p>distributed</p>
 						</div>
 					</div>
 				</div>

--- a/header.svg
+++ b/header.svg
@@ -4,10 +4,10 @@
 			<style>
 				@keyframes rotate {
 					0% {
-						transform: rotateY(270deg);
+						transform: rotateY(0deg);
 					}
 					100% {
-						transform: rotateY(180deg);
+						transform: rotateY(360deg);
 					}
 				}
 
@@ -140,8 +140,6 @@
 									<text x="60" y="235" font-size="50" font-family="Arial" fill="black">[ .org ]</text>
 								</svg>
 							</picture>
-							<h1>Made with HTML &amp; CSS<br/>not an animated GIF</h1>
-							<p>Click to see source</p>
 						</div>
 						<div class="flip-card-back">
 							<h1>John Doe</h1>

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 	<br>
 	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/main/header.svg">
 		<picture>
-		  <source media="(min-width: 720px)" srcset="header.svg">
+		  <img src="header.svg" width="800" height="400" alt="Click to see the source">
 		</picture>
 	</a>
 	<br>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,6 @@
 	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/main/header.svg">
 		<picture>
 		  <source media="(min-width: 720px)" srcset="header.svg">
-		  <img src="header-mobile.svg" width="800" height="400" alt="Click to see the source">
 		</picture>
 	</a>
 	<br>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,7 @@
 <div align="center">
 	<br>
-	<a href="https://github.com/sindresorhus/css-in-readme-like-wat/blame/main/header.svg">
-		<picture>
+	<a href="../../blame/main/header.svg">
 		  <img src="header.svg" width="800" height="400" alt="Click to see the source">
-		</picture>
 	</a>
 	<br>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,6 @@
 <div align="center">
 	<br>
-	<a href="../../blame/main/header.svg">
-		  <img src="header.svg" width="800" height="400" alt="Click to see the source">
-	</a>
+		<img src="header.svg" width="800" height="400" alt="Click to see the source">
 	<br>
 </div>
 <br>


### PR DESCRIPTION
Hi!

**Thank you** for the brilliant SVG technique - I tried applying it to an animated logo I'm making, but can't quite get a rotationY animation to work - the PR is my attempt.

When displayed on its own, the SVG plays as I would expect, but when embeeded, the backface seems to not be hidden, causing the backside text to appear overlayed on the frontface, as seen below:

## Embedded into readme:

![https://raw.githubusercontent.com/drok/css-in-readme-like-wat/exp28/header.svg](https://raw.githubusercontent.com/drok/css-in-readme-like-wat/exp28/header.svg)

## Standalone SVG:

https://raw.githubusercontent.com/drok/css-in-readme-like-wat/exp28/header.svg

However, embedding the SVG into README.md breaks the animation - any idea why?

I also note that the  "distributed digital library" text flashes in the README.md at the beginning of the animation, but does not flash in the standalone image

Thanks for any insight
Cheers